### PR TITLE
Reorderable list

### DIFF
--- a/examples/reorderable_list.rs
+++ b/examples/reorderable_list.rs
@@ -20,31 +20,28 @@ struct MyAppLogic {
 
 impl MyAppLogic {
     fn run(&mut self, cx: &mut Cx) {
-        let mut swap_upwards_id = None;
-        let mut swap_downwards_id = None;
+        let mut rows_to_swap = None;
+        let data = &self.data;
         self.list_view
-            .run(cx, &self.data, |cx, _is_selected, id: Id, item| {
+            .run(cx, data, |cx, _is_selected, id: Id, item| {
                 Row::new().build(cx, |cx| {
                     if Button::new("Up").build(cx) {
-                        swap_upwards_id = Some(id);
+                        let this_ix = data.find_id(id).unwrap();
+                        if this_ix != 0 {
+                            rows_to_swap = Some((this_ix - 1, this_ix));
+                        }
                     }
                     Label::new(item.clone()).build(cx);
                     if Button::new("Down").build(cx) {
-                        swap_downwards_id = Some(id);
+                        let this_ix = data.find_id(id).unwrap();
+                        if this_ix < data.len() - 1 {
+                            rows_to_swap = Some((this_ix, this_ix + 1));
+                        }
                     }
                 });
             });
-        if let Some(id) = swap_upwards_id {
-            let this_ix = self.data.find_id(id).unwrap();
-            if this_ix > 0 {
-                self.data.swap(this_ix - 1, this_ix);
-            }
-        }
-        if let Some(id) = swap_downwards_id {
-            let this_ix = self.data.find_id(id).unwrap();
-            if this_ix < self.data.len() - 1 {
-                self.data.swap(this_ix, this_ix + 1);
-            }
+        if let Some((ix_a, ix_b)) = rows_to_swap {
+            self.data.rows_to_swap(ix_a, ix_b);
         }
     }
 }

--- a/examples/reorderable_list.rs
+++ b/examples/reorderable_list.rs
@@ -1,0 +1,60 @@
+//! A button which can move through a list of labels.
+
+use druid::{AppLauncher, PlatformError, Widget, WindowDesc};
+
+use crochet::{AppHolder, Button, Cx, DruidAppData, Id, Label, List, ListData, Row};
+
+fn main() -> Result<(), PlatformError> {
+    let main_window = WindowDesc::new(ui_builder);
+    let data = Default::default();
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)
+}
+
+#[derive(Default)]
+struct MyAppLogic {
+    data: ListData<String>,
+    list_view: List,
+}
+
+impl MyAppLogic {
+    fn run(&mut self, cx: &mut Cx) {
+        let mut swap_upwards_id = None;
+        let mut swap_downwards_id = None;
+        self.list_view
+            .run(cx, &self.data, |cx, _is_selected, id: Id, item| {
+                Row::new().build(cx, |cx| {
+                    if Button::new("Up").build(cx) {
+                        swap_upwards_id = Some(id);
+                    }
+                    Label::new(item.clone()).build(cx);
+                    if Button::new("Down").build(cx) {
+                        swap_downwards_id = Some(id);
+                    }
+                });
+            });
+        if let Some(id) = swap_upwards_id {
+            let this_ix = self.data.find_id(id).unwrap();
+            if this_ix > 0 {
+                self.data.swap(this_ix - 1, this_ix);
+            }
+        }
+        if let Some(id) = swap_downwards_id {
+            let this_ix = self.data.find_id(id).unwrap();
+            if this_ix < self.data.len() - 1 {
+                self.data.swap(this_ix, this_ix + 1);
+            }
+        }
+    }
+}
+
+fn ui_builder() -> impl Widget<DruidAppData> {
+    let mut app_logic = MyAppLogic::default();
+    app_logic.data.push("Alpha".into());
+    app_logic.data.push("Beta".into());
+    app_logic.data.push("Gamma".into());
+    app_logic.data.push("Delta".into());
+
+    AppHolder::new(move |cx| app_logic.run(cx))
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -87,6 +87,10 @@ impl<T> ListData<T> {
         // A scalable version would not be O(n) here
         self.0.iter().position(|item| id == item.stable_id)
     }
+
+    pub fn swap(&mut self, ix_a: usize, ix_b: usize) {
+        self.0.swap(ix_a, ix_b);
+    }
 }
 
 impl List {


### PR DESCRIPTION
This has some buttons which can move around, but they keep the same Id.

It would have been nice if I could borrow self.data inside the callback immutably, as I first tried it:
https://github.com/tbelaire/crochet/blob/wishful-thinking/examples/travelling_button.rs#L30

I can see that `self.data` is already borrowed immutably, so I don't see why I cant borrow it immutably again.  It'd be nice to avoid this kinda ugly pattern if possible.


Anyways, this moving of rows around is something fairly reasonable for the gui to do.  It suffers from the same bug in #5, as swapping the data doesn't seem to trigger an update.

I know you were aiming for the Optimistic Merge pattern, but I don't actually trust my code to be idiomatic, and would rather have some code review if you don't mind.
