### PR TITLE
fix(ListData): Allow Default for T types that don't implement Default

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -17,8 +17,13 @@ use crate::Cx;
 /// Obviously right now the implementation is super-simple and
 /// not efficient. But the idea is that a similar interface might
 /// support some fancy incremental implementation.
-#[derive(Default)]
 pub struct ListData<T>(Vec<ListItem<T>>);
+
+impl<T> Default for ListData<T> {
+    fn default() -> Self {
+        ListData(Vec::new())
+    }
+}
 
 struct ListItem<T> {
     stable_id: Id,


### PR DESCRIPTION
ListData in the core is a Vec and Vec also allows implementing Default if it's Item do not implement Default. This change makes the same thing possible while the derive strictly requires T to implement Default.