### PR TITLE
Port the Padding widget.

### DIFF
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -28,13 +28,12 @@ impl MyAppLogic {
                 if Button::new("Increment").build(cx) {
                     self.count += 1;
                 }
-                Padding::new().top(10.0).build(cx, |cx| {
-                    if self.count > 3 && self.count < 6 {
+                if self.count > 3 && self.count < 6 {
+                    Padding::new().top(10.0).build(cx, |cx| {
                         Label::new("You did it!").build(cx);
-                    } else {
-                        Label::new("Keep going!").build(cx);
-                    }
-                });
+                        Label::new("Great!").build(cx);
+                    });
+                }
             });
         });
     }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -22,7 +22,7 @@ impl MyAppLogic {
         // Note: the if_changed block here is not really necessary, but it
         // helps test it out.
         cx.if_changed(self.count, |cx| {
-            //println!("traversing into if_changed block");
+            println!("traversing into if_changed block");
             Column::new().build(cx, |cx| {
                 Label::new(format!("current count: {}", self.count)).build(cx);
                 if Button::new("Increment").build(cx) {
@@ -31,7 +31,6 @@ impl MyAppLogic {
                 if self.count > 3 && self.count < 6 {
                     Padding::new().top(10.0).build(cx, |cx| {
                         Label::new("You did it!").build(cx);
-                        Label::new("Great!").build(cx);
                     });
                 }
             });

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -2,7 +2,7 @@
 
 use druid::{AppLauncher, PlatformError, Widget, WindowDesc};
 
-use crochet::{AppHolder, Button, Column, Cx, DruidAppData, Label};
+use crochet::{AppHolder, Button, Column, Cx, DruidAppData, Label, Padding};
 
 fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(ui_builder);
@@ -22,15 +22,19 @@ impl MyAppLogic {
         // Note: the if_changed block here is not really necessary, but it
         // helps test it out.
         cx.if_changed(self.count, |cx| {
-            println!("traversing into if_changed block");
+            //println!("traversing into if_changed block");
             Column::new().build(cx, |cx| {
                 Label::new(format!("current count: {}", self.count)).build(cx);
                 if Button::new("Increment").build(cx) {
                     self.count += 1;
                 }
-                if self.count > 3 && self.count < 6 {
-                    Label::new("You did it!").build(cx);
-                }
+                Padding::new().top(10.0).build(cx, |cx| {
+                    if self.count > 3 && self.count < 6 {
+                        Label::new("You did it!").build(cx);
+                    } else {
+                        Label::new("Keep going!").build(cx);
+                    }
+                });
             });
         });
     }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -34,17 +34,15 @@ impl HelloState {
     }
 
     fn run(&mut self, cx: &mut Cx) {
-        Padding::new()
-            .uniform(5.0 * (self.name.len() as f64))
-            .build(cx, |cx| {
-                Column::new().build(cx, |cx| {
-                    Label::new(self.name_label()).build(cx);
-                    Padding::new().top(5.0).build(cx, |cx| {
-                        if let Some(name) = TextBox::new(&self.name).build(cx) {
-                            self.name = name;
-                        }
-                    });
+        Padding::from(5.0 * (self.name.len() as f64)).build(cx, |cx| {
+            Column::new().build(cx, |cx| {
+                Label::new(self.name_label()).build(cx);
+                Padding::new().top(5.0).build(cx, |cx| {
+                    if let Some(name) = TextBox::new(&self.name).build(cx) {
+                        self.name = name;
+                    }
                 });
             });
+        });
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -34,15 +34,17 @@ impl HelloState {
     }
 
     fn run(&mut self, cx: &mut Cx) {
-        Padding::new().uniform(5.0 * (self.name.len() as f64)).build(cx, |cx| {
-            Column::new().build(cx, |cx| {
-                Label::new(self.name_label()).build(cx);
-                Padding::new().top(5.0).build(cx, |cx| {
-                    if let Some(name) = TextBox::new(&self.name).build(cx) {
-                        self.name = name;
-                    }
+        Padding::new()
+            .uniform(5.0 * (self.name.len() as f64))
+            .build(cx, |cx| {
+                Column::new().build(cx, |cx| {
+                    Label::new(self.name_label()).build(cx);
+                    Padding::new().top(5.0).build(cx, |cx| {
+                        if let Some(name) = TextBox::new(&self.name).build(cx) {
+                            self.name = name;
+                        }
+                    });
                 });
             });
-        });
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,7 +2,7 @@
 
 use druid::{AppLauncher, PlatformError, Widget, WindowDesc};
 
-use crochet::{AppHolder, Column, Cx, DruidAppData, Label, TextBox};
+use crochet::{AppHolder, Column, Cx, DruidAppData, Label, Padding, TextBox};
 
 fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(ui_builder);
@@ -34,11 +34,15 @@ impl HelloState {
     }
 
     fn run(&mut self, cx: &mut Cx) {
-        Column::new().build(cx, |cx| {
-            Label::new(self.name_label()).build(cx);
-            if let Some(name) = TextBox::new(&self.name).build(cx) {
-                self.name = name;
-            }
+        Padding::new().uniform(5.0 * (self.name.len() as f64)).build(cx, |cx| {
+            Column::new().build(cx, |cx| {
+                Label::new(self.name_label()).build(cx);
+                Padding::new().top(5.0).build(cx, |cx| {
+                    if let Some(name) = TextBox::new(&self.name).build(cx) {
+                        self.name = name;
+                    }
+                });
+            });
         });
     }
 }

--- a/src/any_widget.rs
+++ b/src/any_widget.rs
@@ -6,7 +6,7 @@ use druid::widget::{Button, Click, ControllerHost, Label};
 use druid::Data;
 
 use crate::view;
-use crate::widget::{Flex, TextBox};
+use crate::widget::{Flex, Padding, TextBox};
 use crate::{Id, MutIterItem, MutationIter, Payload};
 
 /// The type we use for app data for Druid integration.
@@ -38,6 +38,7 @@ pub enum AnyWidget {
     Label(Label<DruidAppData>),
     Flex(Flex),
     TextBox(TextBox),
+    Padding(Padding),
     /// A do-nothing container for another widget.
     ///
     /// Currently we use this for state nodes.
@@ -58,6 +59,7 @@ macro_rules! methods {
             AnyWidget::Label(w) => w.$method_name($($args),+),
             AnyWidget::Flex(w) => w.$method_name($($args),+),
             AnyWidget::TextBox(w) => w.$method_name($($args),+),
+            AnyWidget::Padding(w) => w.$method_name($($args),+),
             AnyWidget::Passthrough(w) => w.$method_name($($args),+),
         }
     };
@@ -130,6 +132,7 @@ impl AnyWidget {
                     }
                 }
             }
+            AnyWidget::Padding(p) => p.mutate(ctx, body, mut_iter),
             AnyWidget::Passthrough(p) => {
                 if let Some(MutIterItem::Update(body, iter)) = mut_iter.next() {
                     p.mutate_update(ctx, body, iter);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,4 @@ pub use id::Id;
 pub use list::{List, ListData};
 pub use state::State;
 pub use tree::{MutCursor, MutIterItem, Mutation, MutationIter, Payload, Tree};
-pub use view::{Button, Column, Label, Row, TextBox};
+pub use view::{Button, Column, Label, Padding, Row, TextBox};

--- a/src/view.rs
+++ b/src/view.rs
@@ -188,6 +188,12 @@ pub struct Padding {
     pub(crate) insets: druid::Insets,
 }
 
+impl<I: Into<druid::Insets>> From<I> for Padding {
+    fn from(insets: I) -> Self {
+        Padding { insets: insets.into() }
+    }
+}
+
 impl Padding {
     pub fn new() -> Padding {
         Padding {

--- a/src/view.rs
+++ b/src/view.rs
@@ -183,6 +183,52 @@ impl View for TextBox {
     }
 }
 
+#[derive(Debug)]
+pub struct Padding {
+    pub(crate) insets: druid::Insets,
+}
+
+impl Padding {
+    pub fn new() -> Padding {
+        Padding {
+            insets: druid::Insets::ZERO,
+        }
+    }
+
+    pub fn uniform(mut self, insets: f64) -> Self {
+        self.insets = druid::Insets::uniform(insets);
+        self
+    }
+
+    pub fn top(mut self, insets: f64) -> Self {
+        self.insets.y0 = insets;
+        self
+    }
+
+    #[track_caller]
+    pub fn build<T>(self, cx: &mut Cx, f: impl FnOnce(&mut Cx) -> T) -> T {
+        cx.begin_view(Box::new(self), Location::caller());
+        let result = f(cx);
+        cx.end();
+        result
+    }
+}
+
+impl View for Padding {
+    fn same(&self, other: &dyn View) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<Self>() {
+            self.insets == other.insets
+        } else {
+            false
+        }
+    }
+
+    fn make_widget(&self, _id: Id) -> AnyWidget {
+        let row = crate::widget::Padding::new(self.insets);
+        AnyWidget::Padding(row)
+    }
+}
+
 // TODO: this is commented out because the widget is not written yet.
 /*
 /// A wrapper for detecting click gestures.

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -7,4 +7,7 @@ pub use flex::Flex;
 mod textbox;
 pub use textbox::TextBox;
 
+mod padding;
+pub use padding::Padding;
+
 // TODO: want a "clicked" wrapper.

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -1,0 +1,197 @@
+// Copyright 2018 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A widget that just adds padding during layout.
+
+use druid::kurbo::{Insets, Point, Rect, Size};
+use druid::{
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetPod,
+};
+
+// Addition for Crochet.
+use crate::{DruidAppData, MutIterItem, Payload, any_widget::AnyWidget, view};
+use druid::widget::SizedBox;
+
+/// A widget that just adds padding around its child.
+pub struct Padding {
+    left: f64,
+    right: f64,
+    top: f64,
+    bottom: f64,
+
+    child: Option<Box<WidgetPod<DruidAppData, AnyWidget>>>,
+}
+
+// Addition for Crochet.
+impl Padding {
+    pub(crate) fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, mut_iter: crate::MutationIter) {
+        if let Some(Payload::View(view)) = body {
+            if let Some(v) = view.as_any().downcast_ref::<view::Padding>() {
+                let insets = v.insets;
+                self.left = insets.x0;
+                self.right = insets.x1;
+                self.top = insets.y0;
+                self.bottom = insets.y1;
+
+                ctx.request_layout();
+            }
+        }
+
+        let mut ix = 0;
+        let mut children_changed = false;
+        for item in mut_iter {
+            match item {
+                MutIterItem::Skip(n) => {
+                    println!("skipping {} items", n);
+                    ix += n;
+                },
+                MutIterItem::Delete(n) => {
+                    println!("deleting {} items", n);
+                    self.child = None;
+                    children_changed = true;
+                }
+                MutIterItem::Insert(id, body, child_iter) => {
+                    println!("inserting item");
+                    let child = AnyWidget::mutate_insert(ctx, id, body, child_iter);
+                    self.child = Some(Box::new(WidgetPod::new(child)));
+                    ix += 1;
+                    children_changed = true;
+                }
+                MutIterItem::Update(body, child_iter) => {
+                    println!("updating item");
+                    self.child
+                        .as_mut()
+                        .unwrap()
+                        .widget_mut()
+                        .mutate_update(ctx, body, child_iter);
+                    ix += 1;
+                }
+            }
+        }
+        if children_changed {
+            // Note: I'm still getting "old_data missing in WidgetId(_), skipping update"
+            // errors even though I'm doing this. Not sure what's going on, probably
+            // something to look into when doing the real integration.
+            ctx.children_changed();
+        }
+    }
+}
+
+impl Padding {
+    /// Create a new widget with the specified padding. This can either be an instance
+    /// of [`kurbo::Insets`], a f64 for uniform padding, a 2-tuple for axis-uniform padding
+    /// or 4-tuple with (left, top, right, bottom) values.
+    ///
+    /// # Examples
+    ///
+    /// Uniform padding:
+    ///
+    /// ```
+    /// use druid::widget::{Label, Padding};
+    /// use druid::kurbo::Insets;
+    ///
+    /// let _: Padding<()> = Padding::new(10.0, Label::new("uniform!"));
+    /// let _: Padding<()> = Padding::new(Insets::uniform(10.0), Label::new("uniform!"));
+    /// ```
+    ///
+    /// Uniform padding across each axis:
+    ///
+    /// ```
+    /// use druid::widget::{Label, Padding};
+    /// use druid::kurbo::Insets;
+    ///
+    /// let child: Label<()> = Label::new("I need my space!");
+    /// let _: Padding<()> = Padding::new((10.0, 20.0), Label::new("more y than x!"));
+    /// // equivalent:
+    /// let _: Padding<()> = Padding::new(Insets::uniform_xy(10.0, 20.0), Label::new("ditto :)"));
+    /// ```
+    ///
+    /// [`kurbo::Insets`]: https://docs.rs/kurbo/0.5.3/kurbo/struct.Insets.html
+    pub fn new(insets: impl Into<Insets>) -> Self {
+        let insets = insets.into();
+        Padding {
+            left: insets.x0,
+            right: insets.x1,
+            top: insets.y0,
+            bottom: insets.y1,
+            child: None,
+        }
+    }
+}
+
+impl Widget<DruidAppData> for Padding {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut DruidAppData, env: &Env) {
+        if let Some(child) = &mut self.child {
+            child.event(ctx, event, data, env)
+        }
+    }
+
+    fn lifecycle(
+        &mut self,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        data: &DruidAppData,
+        env: &Env,
+    ) {
+        if let Some(child) = &mut self.child {
+            child.lifecycle(ctx, event, data, env)
+        }
+    }
+
+    fn update(
+        &mut self,
+        ctx: &mut UpdateCtx,
+        _old_data: &DruidAppData,
+        data: &DruidAppData,
+        env: &Env,
+    ) {
+        if let Some(child) = &mut self.child {
+            child.update(ctx, data, env);
+        }
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &DruidAppData,
+        env: &Env,
+    ) -> Size {
+        bc.debug_check("Padding");
+
+        if let Some(child) = &mut self.child {
+            let hpad = self.left + self.right;
+            let vpad = self.top + self.bottom;
+
+            let child_bc = bc.shrink((hpad, vpad));
+            let size = child.layout(ctx, &child_bc, data, env);
+            let origin = Point::new(self.left, self.top);
+            child.set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
+
+            let my_size = Size::new(size.width + hpad, size.height + vpad);
+            let my_insets = child.compute_parent_paint_insets(my_size);
+            ctx.set_paint_insets(my_insets);
+            my_size
+        } else {
+            Size::ZERO
+        }
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &DruidAppData, env: &Env) {
+        if let Some(child) = &mut self.child {
+            child.paint(ctx, data, env);
+        }
+    }
+}


### PR DESCRIPTION
There are two interesting things about this:

First, I had to copy the `Padding` widget and change its child type to `AnyWidget`, otherwise I could not call `mutate_update`. So I don't think we can use any of Druids container widgets that use `WidgetPod<dyn Widget<T>>` for their child.

Second, I had to find a way to deal with the fact that the Crochet style of writing the UI does not offer a good way to deal with single child containers. For simplicity, I chose to allow multiple children and just warn about it, then only apply events to the first child.