### PR TITLE
Re-pin druid to work around kurbo conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ features = ["async-std"]
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-rev = "7a3251b9b89df11af653189f2be04c7304861acf"
+branch = "temp-patch-for-crochet"
 
 [dependencies]
 log = "0.4.11"


### PR DESCRIPTION
This is not a robust solution, but at least allows for
crochet to compile as it had previously.