### PR TITLE
Get tests passing

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -28,7 +28,7 @@ pub struct Item {
 ///
 /// Conceptually, a tree follows this grammar:
 ///
-/// ```
+/// ```no_compile
 /// tree := element*
 /// element := begin attribute* tree end
 /// ```


### PR DESCRIPTION
rustdoc was assuming that this code block was a doctest.