### PR TITLE
Update Druid and fix LifeCycle issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/python/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ features = ["async-std"]
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-branch = "temp-patch-for-crochet"
+rev = "aac8103ed68d6654f2e1f6d360b1e6cb7993e787"
+features = ["crochet"]
 
 [dependencies]
 log = "0.4.11"

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,0 +1,20 @@
+//! A minimal example.
+
+use crochet::{AppHolder, Cx, DruidAppData};
+use druid::{AppLauncher, PlatformError, Widget, WindowDesc};
+
+fn main() -> Result<(), PlatformError> {
+    let main_window = WindowDesc::new(ui_builder);
+    let data = Default::default();
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)
+}
+
+fn ui_builder() -> impl Widget<DruidAppData> {
+    AppHolder::new(run)
+}
+
+fn run(cx: &mut Cx) {
+    crochet::Label::new("Hello, world!").build(cx);
+}

--- a/src/any_widget.rs
+++ b/src/any_widget.rs
@@ -122,7 +122,7 @@ impl AnyWidget {
                 if let Some(Payload::View(view)) = body {
                     if let Some(v) = view.as_any().downcast_ref::<view::Label>() {
                         l.set_text(v.0.to_string());
-                        ctx.request_layout();
+                        ctx.request_update();
                     }
                 }
             }

--- a/src/app_holder.rs
+++ b/src/app_holder.rs
@@ -63,7 +63,9 @@ impl AppHolder {
         (self.app_logic)(&mut cx);
         let mutation = cx.into_mutation();
         let mut_iter = MutationIter::new(&self.tree, &mutation);
-        self.child.widget_mut().mutate_update(ctx, None, mut_iter);
+        self.child.with_event_context(ctx, |child, ctx| {
+            child.mutate_update(ctx, None, mut_iter);
+        });
         self.tree.mutate(mutation);
         // This will bring the ui up-to-date and avoid stale state.
         // A better solution would be nice, but this is simple and seems to work.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -114,7 +114,7 @@ pub enum MutIterItem<'a> {
     Update(Option<&'a Payload>, MutationIter<'a>),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 /// An iterator for reading out a tree mutation.
 pub struct MutationIter<'a> {
     tree: &'a Tree,

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -19,7 +19,7 @@ impl Checkbox {
     }
 
     pub fn set_text(&mut self, label: String) {
-        self.inner = WidgetPod::new(druid::widget::Checkbox::new(label));
+        self.inner.widget_mut().set_text(label);
     }
 }
 

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -575,8 +575,9 @@ impl Flex {
                 MutIterItem::Update(body, child_iter) => {
                     self.children[ix]
                         .widget
-                        .widget_mut()
-                        .mutate_update(ctx, body, child_iter);
+                        .with_event_context(ctx, |child, ctx| {
+                            child.mutate_update(ctx, body, child_iter);
+                        });
                     ix += 1;
                 }
             }

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -71,9 +71,9 @@ impl Padding {
                     children_changed = true;
                 }
                 MutIterItem::Update(body, child_iter) => {
-                    self.children[ix]
-                        .widget_mut()
-                        .mutate_update(ctx, body, child_iter);
+                    self.children[ix].with_event_context(ctx, |child, ctx| {
+                        child.mutate_update(ctx, body, child_iter);
+                    });
                     ix += 1;
                 }
             }

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -5,11 +5,11 @@ use druid::{widget::prelude::*, WidgetPod};
 pub struct TextBox {
     id: Id,
     content: String,
-    inner: WidgetPod<String, druid::widget::TextBox>,
+    inner: WidgetPod<String, druid::widget::TextBox<String>>,
 }
 
 impl TextBox {
-    pub fn new(id: Id, content: String, inner: druid::widget::TextBox) -> Self {
+    pub fn new(id: Id, content: String, inner: druid::widget::TextBox<String>) -> Self {
         let inner = WidgetPod::new(inner);
         TextBox { id, content, inner }
     }


### PR DESCRIPTION
Now all `WidgetAdded`, as well as `update` and `layout` should be delivered correctly, with the added benefit of an up-to-date Druid.