### PR TITLE
Add SizedBox and Painter widgets.

### DIFF
--- a/examples/painting.rs
+++ b/examples/painting.rs
@@ -1,0 +1,150 @@
+//! A Painter example.
+
+use crochet::{AppHolder, Column, Cx, DruidAppData, Padding, Painter, Row, SizedBox, TextBox};
+use druid::{AppLauncher, Env, PaintCtx, PlatformError, Widget, WindowDesc};
+
+fn main() -> Result<(), PlatformError> {
+    let main_window = WindowDesc::new(ui_builder).window_size((450.0, 450.0));
+    let data = Default::default();
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)
+}
+
+fn ui_builder() -> impl Widget<DruidAppData> {
+    let mut app = App::new();
+    AppHolder::new(move |cx| app.run(cx))
+}
+
+struct App {
+    first_string: String,
+    second_string: String,
+}
+
+impl App {
+    pub fn new() -> Self {
+        App {
+            first_string: "Hello".to_string(),
+            second_string: "World".to_string(),
+        }
+    }
+
+    pub fn run(&mut self, cx: &mut Cx) {
+        Column::new().build(cx, |cx| {
+            Padding::new().uniform(5.0).build(cx, |cx| {
+                Row::new().build(cx, |cx| {
+                    if let Some(new_first_string) = TextBox::new(&self.first_string).build(cx) {
+                        self.first_string = new_first_string;
+                    }
+                    if let Some(new_second_string) = TextBox::new(&self.second_string).build(cx) {
+                        self.second_string = new_second_string;
+                    }
+                });
+            });
+            SizedBox::new().uniform(400.0).build(cx, |cx| {
+                let data = (self.first_string.clone(), self.second_string.clone());
+                Painter::new(data.clone()).build(cx, |ctx, env, (first, second)| {
+                    paint(ctx, env, first, second);
+                });
+            });
+        });
+    }
+}
+
+fn paint(ctx: &mut PaintCtx, env: &Env, first: &str, second: &str) {
+    use druid::{
+        kurbo::{BezPath, Point},
+        piet::{ImageFormat, InterpolationMode, Text, TextLayoutBuilder},
+        Affine, Color, FontDescriptor, FontFamily, Rect, RenderContext, TextLayout,
+    };
+
+    // Clear the whole widget with the color of your choice
+    // (ctx.size() returns the size of the layout rect we're painting in)
+    // Note: ctx also has a `clear` method, but that clears the whole context,
+    // and we only want to clear this widget's area.
+    let size = ctx.size();
+    let rect = size.to_rect();
+    ctx.fill(rect, &Color::WHITE);
+
+    // We can paint with a Z index, this indicates that this code will be run
+    // after the rest of the painting. Painting with z-index is done in order,
+    // so first everything with z-index 1 is painted and then with z-index 2 etc.
+    // As you can see this(red) curve is drawn on top of the green curve
+    ctx.paint_with_z_index(1, move |ctx| {
+        let mut path = BezPath::new();
+        path.move_to((0.0, size.height));
+        path.quad_to((40.0, 50.0), (size.width, 0.0));
+        // Create a color
+        let stroke_color = Color::rgb8(128, 0, 0);
+        // Stroke the path with thickness 1.0
+        ctx.stroke(path, &stroke_color, 5.0);
+    });
+
+    // Create an arbitrary bezier path
+    let mut path = BezPath::new();
+    path.move_to(Point::ORIGIN);
+    path.quad_to((40.0, 50.0), (size.width, size.height));
+    // Create a color
+    let stroke_color = Color::rgb8(0, 128, 0);
+    // Stroke the path with thickness 5.0
+    ctx.stroke(path, &stroke_color, 5.0);
+
+    // Rectangles: the path for practical people
+    let rect = Rect::from_origin_size((10.0, 10.0), (100.0, 100.0));
+    // Note the Color:rgba8 which includes an alpha channel (7F in this case)
+    let fill_color = Color::rgba8(0x00, 0x00, 0x00, 0x7F);
+    ctx.fill(rect, &fill_color);
+
+    // Text is easy; in real use TextLayout should either be stored in the
+    // widget and reused, or a label child widget to manage it all.
+    // This is one way of doing it, you can also use a builder-style way.
+    let mut layout = TextLayout::<String>::from_text(first);
+    layout.set_font(FontDescriptor::new(FontFamily::SERIF).with_size(24.0));
+    layout.set_text_color(fill_color);
+    layout.rebuild_if_needed(ctx.text(), env);
+
+    // Let's rotate our text slightly. First we save our current (default) context:
+    ctx.with_save(|ctx| {
+        // Now we can rotate the context (or set a clip path, for instance):
+        // This makes it so that anything drawn after this (in the closure) is
+        // transformed.
+        // The transformation is in radians, but be aware it transforms the canvas,
+        // not just the part you are drawing. So we draw at (80.0, 40.0) on the rotated
+        // canvas, this is NOT the same position as (80.0, 40.0) on the original canvas.
+        ctx.transform(Affine::rotate(std::f64::consts::FRAC_PI_4));
+        layout.draw(ctx, (80.0, 40.0));
+    });
+    // When we exit with_save, the original context's rotation is restored
+
+    // This is the builder-style way of drawing text.
+    let text = ctx.text();
+    let layout = text
+        .new_text_layout(second.to_string())
+        .font(FontFamily::SERIF, 24.0)
+        .text_color(Color::rgb8(128, 0, 0))
+        .build()
+        .unwrap();
+    ctx.draw_text(&layout, (100.0, 25.0));
+
+    // Let's burn some CPU to make a (partially transparent) image buffer
+    let image_data = make_image_data(256, 256);
+    let image = ctx
+        .make_image(256, 256, &image_data, ImageFormat::RgbaSeparate)
+        .unwrap();
+    // The image is automatically scaled to fit the rect you pass to draw_image
+    ctx.draw_image(&image, size.to_rect(), InterpolationMode::Bilinear);
+}
+
+fn make_image_data(width: usize, height: usize) -> Vec<u8> {
+    let mut result = vec![0; width * height * 4];
+    for y in 0..height {
+        for x in 0..width {
+            let ix = (y * width + x) * 4;
+            result[ix] = x as u8;
+            result[ix + 1] = y as u8;
+            result[ix + 2] = !(x as u8);
+            result[ix + 3] = 127;
+        }
+    }
+    result
+}

--- a/src/any_widget.rs
+++ b/src/any_widget.rs
@@ -5,8 +5,11 @@ use druid::widget::prelude::*;
 use druid::widget::{Button, Click, ControllerHost, Label};
 use druid::Data;
 
-use crate::widget::{Checkbox, Click as CrochetClick, Flex, Padding, TextBox};
 use crate::{view, widget::SizedBox};
+use crate::{
+    widget::{Checkbox, Click as CrochetClick, Flex, Padding, TextBox},
+    MutableWidget,
+};
 use crate::{Id, MutIterItem, MutationIter, Payload};
 
 /// The type we use for app data for Druid integration.
@@ -42,6 +45,7 @@ pub enum AnyWidget {
     Padding(Padding),
     Checkbox(Checkbox),
     Click(CrochetClick),
+    Painter(Box<dyn MutableWidget>),
     SizedBox(SizedBox),
     /// A do-nothing container for another widget.
     ///
@@ -66,6 +70,7 @@ macro_rules! methods {
             AnyWidget::Padding(w) => w.$method_name($($args),+),
             AnyWidget::Checkbox(w) => w.$method_name($($args),+),
             AnyWidget::Click(w) => w.$method_name($($args),+),
+            AnyWidget::Painter(w) => w.$method_name($($args),+),
             AnyWidget::SizedBox(w) => w.$method_name($($args),+),
             AnyWidget::Passthrough(w) => w.$method_name($($args),+),
         }
@@ -150,6 +155,7 @@ impl AnyWidget {
                 }
             }
             AnyWidget::Click(c) => c.mutate(ctx, body, mut_iter),
+            AnyWidget::Painter(p) => p.mutate(ctx, body, mut_iter),
             AnyWidget::SizedBox(b) => b.mutate(ctx, body, mut_iter),
             AnyWidget::Passthrough(p) => {
                 if let Some(MutIterItem::Update(body, iter)) = mut_iter.next() {

--- a/src/any_widget.rs
+++ b/src/any_widget.rs
@@ -5,8 +5,8 @@ use druid::widget::prelude::*;
 use druid::widget::{Button, Click, ControllerHost, Label};
 use druid::Data;
 
-use crate::view;
 use crate::widget::{Checkbox, Click as CrochetClick, Flex, Padding, TextBox};
+use crate::{view, widget::SizedBox};
 use crate::{Id, MutIterItem, MutationIter, Payload};
 
 /// The type we use for app data for Druid integration.
@@ -42,6 +42,7 @@ pub enum AnyWidget {
     Padding(Padding),
     Checkbox(Checkbox),
     Click(CrochetClick),
+    SizedBox(SizedBox),
     /// A do-nothing container for another widget.
     ///
     /// Currently we use this for state nodes.
@@ -65,6 +66,7 @@ macro_rules! methods {
             AnyWidget::Padding(w) => w.$method_name($($args),+),
             AnyWidget::Checkbox(w) => w.$method_name($($args),+),
             AnyWidget::Click(w) => w.$method_name($($args),+),
+            AnyWidget::SizedBox(w) => w.$method_name($($args),+),
             AnyWidget::Passthrough(w) => w.$method_name($($args),+),
         }
     };
@@ -148,6 +150,7 @@ impl AnyWidget {
                 }
             }
             AnyWidget::Click(c) => c.mutate(ctx, body, mut_iter),
+            AnyWidget::SizedBox(b) => b.mutate(ctx, body, mut_iter),
             AnyWidget::Passthrough(p) => {
                 if let Some(MutIterItem::Update(body, iter)) = mut_iter.next() {
                     p.mutate_update(ctx, body, iter);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,7 @@ pub use id::Id;
 pub use list::{List, ListData};
 pub use state::State;
 pub use tree::{MutCursor, MutIterItem, Mutation, MutationIter, Payload, Tree};
-pub use widget::SingleChild;
-pub use view::{Button, Checkbox, Clicked, Column, Label, Padding, Row, SizedBox, TextBox};
+pub use view::{
+    Button, Checkbox, Clicked, Column, Label, Padding, Painter, Row, SizedBox, TextBox,
+};
+pub use widget::{MutableWidget, SingleChild};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,5 @@ pub use id::Id;
 pub use list::{List, ListData};
 pub use state::State;
 pub use tree::{MutCursor, MutIterItem, Mutation, MutationIter, Payload, Tree};
-pub use view::{Button, Checkbox, Clicked, Column, Label, Padding, Row, TextBox};
 pub use widget::SingleChild;
+pub use view::{Button, Checkbox, Clicked, Column, Label, Padding, Row, SizedBox, TextBox};

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -18,3 +18,6 @@ pub use checkbox::Checkbox;
 
 mod click;
 pub use click::Click;
+
+mod sized_box;
+pub use sized_box::SizedBox;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -21,3 +21,12 @@ pub use click::Click;
 
 mod sized_box;
 pub use sized_box::SizedBox;
+
+mod painter;
+pub use painter::Painter;
+
+use crate::{DruidAppData, MutationIter, Payload};
+use druid::EventCtx;
+pub trait MutableWidget: druid::Widget<DruidAppData> {
+    fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, mut_iter: MutationIter);
+}

--- a/src/widget/painter.rs
+++ b/src/widget/painter.rs
@@ -1,0 +1,42 @@
+use crate::{view, DruidAppData, MutableWidget, MutationIter, Payload};
+use druid::{widget::prelude::*, Data};
+
+pub struct Painter<D> {
+    view: view::Painter<D>,
+}
+
+impl<D: Data> Painter<D> {
+    pub fn new(view: view::Painter<D>) -> Self {
+        Painter { view }
+    }
+}
+
+impl<T: Data> MutableWidget for Painter<T> {
+    fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, _: MutationIter) {
+        if let Some(Payload::View(view)) = body {
+            if let Some(v) = view.as_any().downcast_ref::<view::Painter<T>>() {
+                self.view = v.clone();
+                ctx.request_paint();
+            }
+        }
+    }
+}
+
+impl<T: Data> Widget<DruidAppData> for Painter<T> {
+    fn event(&mut self, _: &mut EventCtx, _: &Event, _: &mut DruidAppData, _: &Env) {}
+    fn lifecycle(&mut self, _: &mut LifeCycleCtx, _: &LifeCycle, _: &DruidAppData, _: &Env) {}
+    fn update(&mut self, _: &mut UpdateCtx, _: &DruidAppData, _: &DruidAppData, _: &Env) {}
+    fn layout(
+        &mut self,
+        _ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _: &DruidAppData,
+        _: &Env,
+    ) -> Size {
+        bc.max()
+    }
+    fn paint(&mut self, ctx: &mut PaintCtx, _: &DruidAppData, env: &Env) {
+        let data = &self.view.data;
+        (self.view.paint)(ctx, env, data)
+    }
+}

--- a/src/widget/sized_box.rs
+++ b/src/widget/sized_box.rs
@@ -1,0 +1,145 @@
+//! A widget with predefined size.
+
+use crate::{view, DruidAppData, Payload, SingleChild};
+use druid::{widget::prelude::*, Point};
+
+/// A widget with predefined size.
+///
+/// If given a child, this widget forces its child to have a specific width and/or height
+/// (assuming values are permitted by this widget's parent). If either the width or height is not set,
+/// this widget will size itself to match the child's size in that dimension.
+///
+/// If not given a child, SizedBox will try to size itself as close to the specified height
+/// and width as possible given the parent's constraints. If height or width is not set,
+/// it will be treated as zero.
+pub struct SizedBox {
+    width: Option<f64>,
+    height: Option<f64>,
+    inner: SingleChild,
+}
+
+impl SizedBox {
+    pub(crate) fn mutate(
+        &mut self,
+        ctx: &mut EventCtx,
+        body: Option<&Payload>,
+        mut_iter: crate::MutationIter,
+    ) {
+        if let Some(Payload::View(view)) = body {
+            if let Some(v) = view.as_any().downcast_ref::<view::SizedBox>() {
+                self.width = v.width;
+                self.height = v.height;
+                ctx.request_layout();
+            }
+        }
+
+        self.inner.mutate(ctx, mut_iter);
+    }
+}
+
+impl SizedBox {
+    pub fn new(view: &view::SizedBox) -> Self {
+        Self {
+            width: view.width,
+            height: view.height,
+            inner: SingleChild::new(),
+        }
+    }
+
+    fn child_constraints(&self, bc: &BoxConstraints) -> BoxConstraints {
+        // if we don't have a width/height, we don't change that axis.
+        // if we have a width/height, we clamp it on that axis.
+        let (min_width, max_width) = match self.width {
+            Some(width) => {
+                let w = width.max(bc.min().width).min(bc.max().width);
+                (w, w)
+            }
+            None => (bc.min().width, bc.max().width),
+        };
+
+        let (min_height, max_height) = match self.height {
+            Some(height) => {
+                let h = height.max(bc.min().height).min(bc.max().height);
+                (h, h)
+            }
+            None => (bc.min().height, bc.max().height),
+        };
+
+        BoxConstraints::new(
+            Size::new(min_width, min_height),
+            Size::new(max_width, max_height),
+        )
+    }
+}
+
+impl Widget<DruidAppData> for SizedBox {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut DruidAppData, env: &Env) {
+        if let Some(inner) = self.inner.get_mut() {
+            inner.event(ctx, event, data, env);
+        }
+    }
+
+    fn lifecycle(
+        &mut self,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        data: &DruidAppData,
+        env: &Env,
+    ) {
+        if let Some(inner) = self.inner.get_mut() {
+            inner.lifecycle(ctx, event, data, env)
+        }
+    }
+
+    fn update(
+        &mut self,
+        ctx: &mut UpdateCtx,
+        _old_data: &DruidAppData,
+        data: &DruidAppData,
+        env: &Env,
+    ) {
+        if let Some(inner) = self.inner.get_mut() {
+            inner.update(ctx, data, env);
+        }
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &DruidAppData,
+        env: &Env,
+    ) -> Size {
+        bc.debug_check("SizedBox");
+
+        let child_bc = self.child_constraints(bc);
+        let size = match self.inner.get_mut() {
+            Some(inner) => {
+                let size = inner.layout(ctx, &child_bc, data, env);
+                inner.set_origin(ctx, data, env, Point::ZERO);
+                size
+            }
+            None => bc.constrain((self.width.unwrap_or(0.0), self.height.unwrap_or(0.0))),
+        };
+
+        if size.width.is_infinite() {
+            log::warn!("SizedBox is returning an infinite width.");
+        }
+
+        if size.height.is_infinite() {
+            log::warn!("SizedBox is returning an infinite height.");
+        }
+
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &DruidAppData, env: &Env) {
+        if let Some(inner) = self.inner.get_mut() {
+            inner.paint(ctx, data, env);
+        }
+    }
+
+    fn id(&self) -> Option<WidgetId> {
+        self.inner.get().map(|inner| inner.id())
+    }
+}


### PR DESCRIPTION
I wanted to add the `Painter` widget, but in order to use it I needed `SizedBox` (`Painter` uses `bc.max()`).

I've also added a new trait `MutableWidget` which extends `druid::Widget<DruidAppData>` with the `mutate` method.
This was required for `Painter` because I wanted `Painter` to be generic over its painting data.
If it works out well, I might be able to use this for all widgets and remove `AnyWidget`? I'll have to play around with it a bit more.