### PR TITLE
Collaps all variants of AnyWidget into Box<dyn MutableWidget>.

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -50,7 +50,8 @@ impl View for Label {
     }
 
     fn make_widget(&self, _id: Id) -> AnyWidget {
-        AnyWidget::Label(widget::Label::new(self.0.to_string()))
+        let widget = widget::Label::new(self.0.to_string());
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -79,9 +80,9 @@ impl View for Button {
     }
 
     fn make_widget(&self, id: Id) -> AnyWidget {
-        let button = widget::Button::new(self.0.clone())
+        let widget = widget::Button::new(self.0.clone())
             .on_click(move |_, data: &mut DruidAppData, _| data.queue_action(id, Action::Clicked));
-        AnyWidget::Button(button)
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -112,8 +113,8 @@ impl View for Row {
     }
 
     fn make_widget(&self, _id: Id) -> AnyWidget {
-        let row = crate::widget::Flex::row();
-        AnyWidget::Flex(row)
+        let widget = crate::widget::Flex::row();
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -144,8 +145,8 @@ impl View for Column {
     }
 
     fn make_widget(&self, _id: Id) -> AnyWidget {
-        let column = crate::widget::Flex::column();
-        AnyWidget::Flex(column)
+        let widget = crate::widget::Flex::column();
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -178,8 +179,8 @@ impl View for TextBox {
     }
 
     fn make_widget(&self, id: Id) -> AnyWidget {
-        let text_box = crate::widget::TextBox::new(id, self.0.clone(), widget::TextBox::new());
-        AnyWidget::TextBox(text_box)
+        let widget = crate::widget::TextBox::new(id, self.0.clone(), widget::TextBox::new());
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -232,8 +233,8 @@ impl View for Padding {
     }
 
     fn make_widget(&self, _id: Id) -> AnyWidget {
-        let row = crate::widget::Padding::new(self.insets);
-        AnyWidget::Padding(row)
+        let widget = crate::widget::Padding::new(self.insets);
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -276,8 +277,8 @@ impl View for Checkbox {
     }
 
     fn make_widget(&self, id: Id) -> AnyWidget {
-        let checkbox = crate::widget::Checkbox::new(id, self.state, self.label.clone());
-        AnyWidget::Checkbox(checkbox)
+        let widget = crate::widget::Checkbox::new(id, self.state, self.label.clone());
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -310,8 +311,8 @@ impl View for Clicked {
     }
 
     fn make_widget(&self, id: Id) -> AnyWidget {
-        let clicked = crate::widget::Click::new(id);
-        AnyWidget::Click(clicked)
+        let widget = crate::widget::Click::new(id);
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -359,7 +360,7 @@ impl<D: druid::Data> View for Painter<D> {
 
     fn make_widget(&self, _id: Id) -> AnyWidget {
         let widget = crate::widget::Painter::new(self.clone());
-        AnyWidget::Painter(Box::new(widget))
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }
 
@@ -452,6 +453,6 @@ impl View for SizedBox {
 
     fn make_widget(&self, _id: Id) -> AnyWidget {
         let widget = crate::widget::SizedBox::new(&self);
-        AnyWidget::SizedBox(widget)
+        AnyWidget::MutableWidget(Box::new(widget))
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -1,4 +1,4 @@
-use crate::{any_widget::Action, DruidAppData, Id};
+use crate::{any_widget::Action, view, DruidAppData, Id, MutableWidget, MutationIter, Payload};
 use druid::{widget::prelude::*, WidgetPod};
 
 /// A wrapper around `druid::Checkbox` with `DruidAppData` instead of `bool`.
@@ -13,13 +13,17 @@ impl Checkbox {
         let inner = WidgetPod::new(druid::widget::Checkbox::new(label));
         Checkbox { id, state, inner }
     }
+}
 
-    pub fn set_state(&mut self, state: bool) {
-        self.state = state;
-    }
-
-    pub fn set_text(&mut self, label: String) {
-        self.inner.widget_mut().set_text(label);
+impl MutableWidget for Checkbox {
+    fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, _mut_iter: MutationIter) {
+        if let Some(Payload::View(view)) = body {
+            if let Some(v) = view.as_any().downcast_ref::<view::Checkbox>() {
+                self.state = v.state;
+                self.inner.widget_mut().set_text(v.label.clone());
+                ctx.request_update();
+            }
+        }
     }
 }
 

--- a/src/widget/click.rs
+++ b/src/widget/click.rs
@@ -1,6 +1,8 @@
 use druid::{widget::prelude::*, MouseButton, Point};
 
-use crate::{any_widget::Action, DruidAppData, Id, Payload, SingleChild};
+use crate::{
+    any_widget::Action, DruidAppData, Id, MutableWidget, MutationIter, Payload, SingleChild,
+};
 
 pub struct Click {
     id: Id,
@@ -14,13 +16,10 @@ impl Click {
             child: SingleChild::new(),
         }
     }
+}
 
-    pub(crate) fn mutate(
-        &mut self,
-        ctx: &mut EventCtx,
-        _body: Option<&Payload>,
-        mut_iter: crate::MutationIter,
-    ) {
+impl MutableWidget for Click {
+    fn mutate(&mut self, ctx: &mut EventCtx, _body: Option<&Payload>, mut_iter: MutationIter) {
         self.child.mutate(ctx, mut_iter);
     }
 }

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -28,7 +28,10 @@ use druid::{
     PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
-use crate::any_widget::{AnyWidget, DruidAppData};
+use crate::{
+    any_widget::{AnyWidget, DruidAppData},
+    MutableWidget, Payload,
+};
 use crate::{MutIterItem, MutationIter};
 
 /// A container with either horizontal or vertical layout.
@@ -552,8 +555,10 @@ impl Flex {
         self.add_flex_child(child, flex);
     }
     */
+}
 
-    pub(crate) fn mutate(&mut self, ctx: &mut EventCtx, mut_iter: MutationIter) {
+impl MutableWidget for Flex {
+    fn mutate(&mut self, ctx: &mut EventCtx, _body: Option<&Payload>, mut_iter: MutationIter) {
         let mut ix = 0;
         let mut children_changed = false;
         for item in mut_iter {

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -14,7 +14,7 @@
 
 //! A widget that just adds padding during layout.
 
-use crate::{view, DruidAppData, Payload, SingleChild};
+use crate::{view, DruidAppData, MutableWidget, MutationIter, Payload, SingleChild};
 use druid::kurbo::{Insets, Point, Rect, Size};
 use druid::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
@@ -31,13 +31,8 @@ pub struct Padding {
     child: SingleChild,
 }
 
-impl Padding {
-    pub(crate) fn mutate(
-        &mut self,
-        ctx: &mut EventCtx,
-        body: Option<&Payload>,
-        mut_iter: crate::MutationIter,
-    ) {
+impl MutableWidget for Padding {
+    fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, mut_iter: MutationIter) {
         if let Some(Payload::View(view)) = body {
             if let Some(v) = view.as_any().downcast_ref::<view::Padding>() {
                 let insets = v.insets;

--- a/src/widget/sized_box.rs
+++ b/src/widget/sized_box.rs
@@ -1,6 +1,6 @@
 //! A widget with predefined size.
 
-use crate::{view, DruidAppData, Payload, SingleChild};
+use crate::{view, DruidAppData, MutableWidget, MutationIter, Payload, SingleChild};
 use druid::{widget::prelude::*, Point};
 
 /// A widget with predefined size.
@@ -18,13 +18,8 @@ pub struct SizedBox {
     inner: SingleChild,
 }
 
-impl SizedBox {
-    pub(crate) fn mutate(
-        &mut self,
-        ctx: &mut EventCtx,
-        body: Option<&Payload>,
-        mut_iter: crate::MutationIter,
-    ) {
+impl MutableWidget for SizedBox {
+    fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, mut_iter: MutationIter) {
         if let Some(Payload::View(view)) = body {
             if let Some(v) = view.as_any().downcast_ref::<view::SizedBox>() {
                 self.width = v.width;

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -1,4 +1,4 @@
-use crate::{any_widget::Action, DruidAppData, Id};
+use crate::{any_widget::Action, view, DruidAppData, Id, MutableWidget, MutationIter, Payload};
 use druid::{widget::prelude::*, WidgetPod};
 
 /// A wrapper around `druid::TextBox` with `DruidAppData` instead of `String`.
@@ -13,9 +13,16 @@ impl TextBox {
         let inner = WidgetPod::new(inner);
         TextBox { id, content, inner }
     }
+}
 
-    pub fn set_text(&mut self, content: String) {
-        self.content = content;
+impl MutableWidget for TextBox {
+    fn mutate(&mut self, ctx: &mut EventCtx, body: Option<&Payload>, _mut_iter: MutationIter) {
+        if let Some(Payload::View(view)) = body {
+            if let Some(v) = view.as_any().downcast_ref::<view::TextBox>() {
+                self.content = v.0.clone();
+                ctx.request_update();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
After #23 I tried to see how far `MutableWidget` can get us, and it worked out perfectly.
Now `AnyWidget` only has two variants, `AnyWidget::MutableWidget` and `AnyWidget::Passthrough`.

Maybe `AnyWidget::Passthrough` can also be a `dyn MutableWidget`? In that case we could remove `AnyWidget` completely.

@raphlinus what do you think about this?