### PR TITLE
New mutation API

### DIFF
--- a/src/cx.rs
+++ b/src/cx.rs
@@ -10,7 +10,7 @@ use druid::{ExtEventSink, SingleUse, Target};
 #[cfg(feature = "async-std")]
 use async_std::future::Future;
 
-use crate::any_widget::DruidAppData;
+use crate::any_widget::{Action, DruidAppData};
 #[cfg(feature = "async-std")]
 use crate::app_holder::ASYNC;
 use crate::id::Id;
@@ -239,5 +239,36 @@ impl<'a> Cx<'a> {
         self.mut_cursor
             .descendant_ids()
             .any(|id| self.app_data.has_action(id))
+    }
+}
+
+impl<'a> Cx<'a> {
+    #[track_caller]
+    pub fn begin_item(&mut self) -> bool {
+        self.mut_cursor.begin_item()
+    }
+
+    pub fn get_id(&self) -> Id {
+        self.mut_cursor.get_current_id()
+    }
+
+    pub fn dequeue_action(&mut self) -> Option<Action> {
+        self.app_data.dequeue_action(self.get_id())
+    }
+
+    pub fn get_payload(&self) -> Option<&Payload> {
+        self.mut_cursor.get_current_payload()
+    }
+
+    pub fn set_payload(&mut self, payload: Payload) {
+        self.mut_cursor.set_current_payload(payload);
+    }
+
+    pub fn end_item_and_begin_body(&mut self) {
+        self.mut_cursor.end_item_and_begin_body();
+    }
+
+    pub fn end_body(&mut self) {
+        self.mut_cursor.end_body();
     }
 }


### PR DESCRIPTION
While playing around with Crochet and porting the Iced todo example, I wanted to write my own `use_state` and `use_future` hooks, but ended up struggling with the current mutation API, which I think is kind of complicated and limiting.

So instead I put my focus on understanding the `Cx`, `Tree` and `MutCursor` trio in order to define a hopefully simpler, yet more powerful mutation API. For now, it is mostly additions, because I have not yet removed the old API. But with these additions, basically everything else could be removed from `Cx`. Most importantly, `begin_core` can be disposed of. (I hate it)

This new API also allows extracting hooks like `if_changed` and `use_future` from `Cx` and allows writing your own hooks.

So far I've ported the `begin_view`, `leaf_view` and `if_changed` helpers, so most examples are using the new API already.

The API looks like this:
```rust
mpl<'a> Cx<'a> {
    #[track_caller]
    pub fn begin_item(&mut self) -> bool {
        self.mut_cursor.begin_item(Location::caller())
    }

    pub fn begin_item_at(&mut self, location: &'static Location) -> bool {
        self.mut_cursor.begin_item(location)
    }

    pub fn get_id(&self) -> Id {
        self.mut_cursor.get_current_id()
    }

    pub fn dequeue_action(&mut self) -> Option<Action> {
        self.app_data.dequeue_action(self.get_id())
    }

    pub fn get_payload(&self) -> Option<&Payload> {
        self.mut_cursor.get_current_payload()
    }

    pub fn set_payload(&mut self, payload: Payload) {
        self.mut_cursor.set_current_payload(payload);
    }

    pub fn end_item_and_begin_body(&mut self) {
        self.mut_cursor.end_item_and_begin_body();
    }

    pub fn end_body(&mut self) {
        self.mut_cursor.end_body();
    }
}
```

And `if_changed` illustrates how it can be used:
```rust
#[track_caller]
pub fn if_changed<T, U>(&mut self, data: T, f: impl FnOnce(&mut Cx) -> U) -> Option<U>
where
    T: PartialEq + State + 'static,
{
    let location = Location::caller();

    let mut changed = self.begin_item_at(location); // begins a new item, returning whether it is new
    if changed {
        self.set_payload(Payload::State(Box::new(data))); // set the initial payload
    } else {
        if let Some(Payload::State(old_data)) = self.get_payload() { // access the current payload
            if let Some(old_data) = old_data.as_any().downcast_ref::<T>() {
                if old_data != &data {
                    changed = true;
                    self.set_payload(Payload::State(Box::new(data))); // update an existing payload
                }
            } else {
                panic!("State type of an if_changed block changed unexpectedly");
            }
        } else {
            panic!("Payload of if_canged block was not a Payload::State");
        }
    }
    self.end_item_and_begin_body(); // finish the item and begin its body

    let actions = self.has_action();

    let result = if changed || actions {
        Some(f(self)) // create any children
    } else {
        self.mut_cursor.skip_one(); // one thing I'm not sure yet how to expose it as part of the API
        None
    };

    self.end_body(); // "close" this item
    result
}
```

@raphlinus What do you think about this?